### PR TITLE
feat: add typescript types for use in graphql

### DIFF
--- a/graphql/resolvers/index.ts
+++ b/graphql/resolvers/index.ts
@@ -1,5 +1,8 @@
+import { User, Workspace, Project, Item, PropertyCollection, Block } from "../../types/types";
+
 export default {
   Query: {
     hello: () => "Hello world!",
   },
 };
+

--- a/graphql/typedefs/index.ts
+++ b/graphql/typedefs/index.ts
@@ -1,4 +1,5 @@
 import { gql } from "apollo-server-express";
+import { User, Workspace, Project, Item, PropertyCollection, Block } from "../../types/types";
 
 export default gql`
   type Query {

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,0 +1,63 @@
+/* eslint-disable no-use-before-define */
+export interface User {
+    id: string;
+    email: string;
+    name: string;
+    password: string;
+    adminWorkspaces: Workspace[];
+    adminProjects: Project[];
+    workspaces: Workspace[];
+    projects: Project[];
+}
+
+export interface Workspace {
+    id: string;
+    projects: Project[];
+    administrators: Workspace[];
+    users: User[];
+}
+
+
+export interface Project {
+    id: string;
+    name: string;
+    description: string;
+    workspace: Workspace;
+    users: User[];
+    items: Item[];
+    workspaceId: string;
+    administrators: Project[];
+}
+
+
+
+
+
+export interface PropertyCollection {
+    id: string;
+    value?: object;
+    Item: Item[];
+}
+
+
+export interface Item {
+    id: string;
+    title: string;
+    description: string;
+    project: Project[];
+    properties: PropertyCollection;
+    blocks: Block[];
+    subItems: Item[];
+    Item?: Item;
+    itemId?: string;
+    propertyCollectionId: string;
+}
+
+
+export interface Block {
+    id: string;
+    content?: object;
+    Item: Item;
+    itemId: string;
+    type: string;
+}


### PR DESCRIPTION
# Description

I created a typescript file 'types.ts' inside the new folder types. The prisma schema was modified to conform to typescript syntax for use in graphql CRUD operations. Additionally, the files 'index.ts' in graphql/typedefs and graphql/resolvers were updated to import the newly added types as an example. 

The latter two changes are temporary as the index files are intended to be deleted when all typedefs and resolvers have been completed.

<!-- Fixes/Closes # (issue) -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
